### PR TITLE
Create SCSS & LESS files with npm install hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ p {
 
 This package can be installed with:
 
-* [npm](https://www.npmjs.com/package/owl.carousel): `npm install --save system-font-css`
+* [npm](https://www.npmjs.com/package/system-font-css): `npm install --save system-font-css`
 
 ### Load
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ p {
 }
 ```
 
+## Quick Start
+
+### Install
+
+This package can be installed with:
+
+* [npm](https://www.npmjs.com/package/owl.carousel): `npm install --save system-font-css`
+
+### Load
+
+When installed with npm, system-font.css will create both a SCSS and LESS partial for easy importing:
+
+```scss
+@import 'system-font';
+```
+
 ## OSX
 
 **OSX** has used three system typefaces. Since **El Capitan** it has used **San Fransisco**. In **Yosemite** it used **Helvetica Neue**. From **Mavericks** back to **Kodiak** it used **Lucida Grande**.

--- a/package.json
+++ b/package.json
@@ -22,5 +22,7 @@
 	"dependencies": {},
 	"devDependencies": {},
 	"main": "system-font.css",
-	"scripts": {}
+	"scripts": {
+		"install": "cp system-font.css _system-font.scss ; cp system-font.css system-font.less"
+	}
 }


### PR DESCRIPTION
In reference to our discussion on PR #5, I've updated the package.json with an `install` hook that copies the base system-font.css into SCSS and LESS partials. I've also updated the README with installation instructions. Feel free to close the other PR if you decide that this one is beneficial enough to include!