### PR TITLE
Use cross-platform cpr for npm install hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+
+# Exclude generated files
+_system-font.scss
+system-font.less

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
 	"engines": {
 		"node": ">=0.8.0"
 	},
-	"dependencies": {},
+	"dependencies": {
+		"cpr": "^2.2.0"
+	},
 	"devDependencies": {},
 	"main": "system-font.css",
 	"scripts": {
-		"install": "cp system-font.css _system-font.scss ; cp system-font.css system-font.less"
+		"install": "cpr system-font.css _system-font.scss -o && cpr system-font.css system-font.less -o"
 	}
 }


### PR DESCRIPTION
The command `cp` is not available on Windows. The module `cpr` uses Node's `fs` under the hood which works on all platforms.